### PR TITLE
Handle characteristic errors and add cached/optimistic state for Lightbulb

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -102,11 +102,14 @@ export class Accessory implements AccessoryPlugin {
       }
     } catch (error) {
       this.log.error('Failed to update lightbulb state.', error);
-      this.state = previousState;
-      this.lightbulbService.updateCharacteristic(
-        this.api.hap.Characteristic.On,
-        previousState,
-      );
+      // Only revert if no newer request has changed the state
+      if (this.state === targetState) {
+        this.state = previousState;
+        this.lightbulbService.updateCharacteristic(
+          this.api.hap.Characteristic.On,
+          previousState,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent Homebridge "Characteristic" warnings and errors when the Nature Remo API is unavailable by avoiding thrown exceptions from characteristic handlers and always returning a valid value. 
- Improve UX by updating the HomeKit characteristic optimistically while performing the network operation in the background so HomeKit remains responsive.

### Description
- Wrap the `On` characteristic getter in a `try/catch`, cache the last-known state, and return the cached value on error to avoid propagating exceptions. 
- Make the `On` setter perform an optimistic update to the characteristic immediately and call a new async helper `applyLightbulbState` to execute `lightbulb.on()` / `lightbulb.off()` in the background. 
- Reconcile state on failure by logging the error, restoring the previous cached state, and updating the characteristic accordingly. 
- Modified file: `src/accessory.ts`.

### Testing
- Ran the test suite with `npm test` and all tests passed (1 test suite, 3 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ea811c6c832a96123b8308118ad4)